### PR TITLE
Fix null reference in DocumentKindChanged

### DIFF
--- a/sberdev.SBContracts/sberdev.SBContracts.Shared/ContractualDocument/ContractualDocumentHandlers.cs
+++ b/sberdev.SBContracts/sberdev.SBContracts.Shared/ContractualDocument/ContractualDocumentHandlers.cs
@@ -131,13 +131,22 @@ namespace sberdev.SBContracts
       {
         _obj.ModifiedSberDev = Calendar.Now;
         _obj.FrameworkBaseSberDev = false;
-        
+
         var kind = e.NewValue;
-        if (sberdev.SBContracts.DocumentKinds.As(kind).SaveDocSDev.HasValue)
+        if (kind != null)
         {
-          var stor = sberdev.SBContracts.DocumentKinds.As(kind).SaveDocSDev.Value;
-          if (_obj.StorageDocATSDev != stor)
-            _obj.StorageDocATSDev = stor;
+          var docKind = sberdev.SBContracts.DocumentKinds.As(kind);
+          if (docKind != null && docKind.SaveDocSDev.HasValue)
+          {
+            var stor = docKind.SaveDocSDev.Value;
+            if (_obj.StorageDocATSDev != stor)
+              _obj.StorageDocATSDev = stor;
+          }
+          else
+          {
+            if (_obj.StorageDocATSDev != false)
+              _obj.StorageDocATSDev = false;
+          }
         }
         else
         {


### PR DESCRIPTION
## Summary
- avoid null dereference when DocumentKind value cleared

## Testing
- `apt-get update`
- `apt-get install dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687e6e461efc8329be818dddf5944fa7